### PR TITLE
Fix errors in barrett15 kernels with VectorSize=1

### DIFF
--- a/src/mfakto.cpp
+++ b/src/mfakto.cpp
@@ -733,13 +733,6 @@ void set_gpu_type()
     }
   }
 
-  if (mystuff.vectorsize == 1 && mystuff.gpu_type < GPU_CPU)
-  {
-    printf("WARNING: VectorSize=1 is known to fail on AMD GPUs and drivers. "
-           "If the selftest fails, please increase VectorSize to 2 at least. "
-           "See http://community.amd.com/thread/167571 for latest news about this issue.");
-  }
-
   if (((mystuff.gpu_type >= GPU_GCN) && (mystuff.gpu_type <= GPU_GCN3)) && (mystuff.vectorsize > 3))
   {
     printf("\nWARNING: Your GPU was detected as GCN (Graphics Core Next). "


### PR DESCRIPTION
The non-VLIW implementations of the ADD_COND and SUB_COND macros used the AS_UINT_V macro for type conversion from int to uint. However, AS_UINT_V is only meant for the results of comparison results, and the scalar (VectorSize=1) implementation of AS_UINT_V inverts the sign of the argument. As a result, ADD_COND and SUB_COND would produce incorrect results. ADD_COND is unused, SUB_COND is only used in barrett15.cl.

Reimplement ADD_COND and SUB_COND macros to avoid the mususe of the AS_UINT_V macro. To prevent such misuse in the future, implement AS_UINT_V in terms of an inline function.

Remove AS_INT_V, AS_LONG_V and AS_ULONG_V, as they were unused and it's unclear if they were meant for booleans or for general type conversion.

Remove a warning for VectorSize=1, it's obsolete and the link is dead.