### PR TITLE
Define CL_TARGET_OPENCL_VERSION to fix warnings in OpenCL headers

### DIFF
--- a/mfaktoVS12.vcxproj
+++ b/mfaktoVS12.vcxproj
@@ -140,7 +140,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level1</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;BUILD_OPENCL;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(OCL_ROOT)\include</AdditionalIncludeDirectories>
       <TreatWarningAsError>false</TreatWarningAsError>
       <OmitFramePointers>false</OmitFramePointers>
@@ -172,7 +172,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;BUILD_OPENCL;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(OCL_ROOT)\include</AdditionalIncludeDirectories>
       <TreatWarningAsError>false</TreatWarningAsError>
       <OmitFramePointers>false</OmitFramePointers>
@@ -206,7 +206,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>false</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;BUILD_OPENCL;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(OCL_ROOT)\include</AdditionalIncludeDirectories>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
@@ -249,7 +249,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>false</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;BUILD_OPENCL;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(OCL_ROOT)\include</AdditionalIncludeDirectories>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>

--- a/src/Makefile
+++ b/src/Makefile
@@ -71,7 +71,7 @@ OPTIMIZE_FLAG = -O3 -funroll-loops  -ffast-math -finline-functions -frerun-loop-
 # compiler settings for C and C++ files
 CC = gcc
 CPP = $(CC)
-CFLAGS = $(BITS) -Wall $(OPTIMIZE_FLAG) $(AMD_APP_INCLUDE) -DBUILD_OPENCL
+CFLAGS = $(BITS) -Wall $(OPTIMIZE_FLAG) $(AMD_APP_INCLUDE)
 CPPFLAGS =
 #CFLAGS_EXTRA_SIEVE = -funroll-all-loops
 #CFLAGS_EXTRA_SIEVE = -funroll-all-loops -funsafe-loop-optimizations -fira-region=all -fsched-spec-load -fsched-stalled-insns=10 -fsched-stalled-insns-dep=10 -floop-parallelize-all -fvariable-expansion-in-unroller -fno-align-labels

--- a/src/gpusieve.cpp
+++ b/src/gpusieve.cpp
@@ -29,11 +29,6 @@ See (http://www.mersenneforum.org/showthread.php?t=11900) for Ben's initial work
 */
 
 #include <cstdlib>
-#if defined __APPLE__
-  #include "OpenCL/cl.h"
-#else
-  #include "CL/cl.h"
-#endif
 #include <iostream>
 #include <string.h>
 #include <stdio.h>

--- a/src/my_types.h
+++ b/src/my_types.h
@@ -17,12 +17,12 @@ You should have received a copy of the GNU General Public License
 along with mfaktc (mfakto).  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#define CL_USE_DEPRECATED_OPENCL_2_0_APIS
-
 #ifndef __MY_TYPES_H
 #define __MY_TYPES_H
 #include <stdio.h>
 #include "params.h"
+
+#define CL_TARGET_OPENCL_VERSION 120
 #if defined __APPLE__
   #include "OpenCL/cl.h"
 #else

--- a/src/output.c
+++ b/src/output.c
@@ -24,11 +24,6 @@ along with mfaktc.  If not, see <http://www.gnu.org/licenses/>.
 #include <stdarg.h>
 #include <stdbool.h>
 #include <string.h>
-#if defined __APPLE__
-  #include <OpenCL/cl.h>
-#else
-  #include <CL/cl.h>
-#endif
 #include "string.h"
 #include "params.h"
 #include "my_types.h"

--- a/src/perftest.cpp
+++ b/src/perftest.cpp
@@ -24,11 +24,6 @@ along with mfaktc (mfakto).  If not, see <http://www.gnu.org/licenses/>.
 #include <iostream>
 #include <fstream>
 #include "string.h"
-#if defined __APPLE__
-  #include "OpenCL/cl.h"
-#else
-  #include "CL/cl.h"
-#endif
 #include "params.h"
 #include "my_types.h"
 #include "compatibility.h"

--- a/src/read_config.c
+++ b/src/read_config.c
@@ -23,13 +23,6 @@ along with mfaktc (mfakto).  If not, see <http://www.gnu.org/licenses/>.
 #define strcasecmp _stricmp
 #endif
 #include <errno.h>
-#if defined BUILD_OPENCL
-  #if defined __APPLE__
-    #include <OpenCL/cl.h>
-  #else
-    #include <CL/cl.h>
-  #endif
-#endif
 
 #include "params.h"
 #include "my_types.h"

--- a/src/signal_handler.c
+++ b/src/signal_handler.c
@@ -20,13 +20,6 @@ along with mfaktc (mfakto).  If not, see <http://www.gnu.org/licenses/>.
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
-#if defined BUILD_OPENCL
-  #if defined __APPLE__
-    #include <OpenCL/cl.h>
-  #else
-    #include <CL/cl.h>
-  #endif
-#endif
 
 #include "params.h"
 #include "my_types.h"


### PR DESCRIPTION
Set CL_TARGET_OPENCL_VERSION to 120 (OpenCL 1.2). Only include OpenCL headers through my_types.h to ensure that CL_TARGET_OPENCL_VERSION is defined before OpenCL headers.

Don't define BUILD_OPENCL, it was controlling whether OpenCL headers are included before my_types.h.

Don't define CL_USE_DEPRECATED_OPENCL_2_0_APIS, it's not needed anymore. Programs that target OpenCL 1.2 are free to use functions obsoleted in later versions of OpenCL.