### PR TITLE
RDNA3 support

### DIFF
--- a/src/mfaktc.c
+++ b/src/mfaktc.c
@@ -376,6 +376,28 @@ GPUKernels find_fastest_kernel(mystuff_t *mystuff, cl_uint do_test)
       UNKNOWN_KERNEL,
       UNKNOWN_KERNEL },
     {
+        /*  GPU_RDNA3  (3rd gen RDNA) (only barett tested) */
+      BARRETT69_MUL15,
+      BARRETT70_MUL15,
+      BARRETT71_MUL15,
+      BARRETT76_MUL32,
+      BARRETT77_MUL32,
+      BARRETT87_MUL32,
+      BARRETT88_MUL32,
+      BARRETT73_MUL15,
+      BARRETT74_MUL15,
+      BARRETT79_MUL32,
+      BARRETT92_MUL32,
+      MG62,
+      _63BIT_MUL24,
+      _71BIT_MUL24,
+      MG88,
+      UNKNOWN_KERNEL,
+      UNKNOWN_KERNEL,
+      UNKNOWN_KERNEL,
+      UNKNOWN_KERNEL,
+      UNKNOWN_KERNEL }, // TODO fix failures in kernels: {'cl_barrett15_83_gs': 33323, 'cl_barrett15_88_gs': 33764, 'cl_barrett15_82_gs': 33225}
+    {
 /*  GPU_APU,  (BeaverCreek=???, v=4)  */
       BARRETT70_MUL15,  // "cl_barrett15_70" (79.66 M/s)
       BARRETT69_MUL15,  // "cl_barrett15_69" (78.40 M/s)

--- a/src/mfaktc.c
+++ b/src/mfaktc.c
@@ -60,6 +60,7 @@ GPU_type gpu_types[]={
   {GPU_GCN5,    64,  "GCN5"},
   {GPU_GCNF,    64,  "GCNF"},
   {GPU_RDNA,    64,  "RDNA"},
+  {GPU_RDNA3,   64,  "RDNA3"},
   {GPU_APU,     80,  "APU"},
   {GPU_CPU,      1,  "CPU"},
   {GPU_NVIDIA,   8,  "NVIDIA"},

--- a/src/mfakto.cpp
+++ b/src/mfakto.cpp
@@ -675,6 +675,10 @@ void set_gpu_type()
     {
       mystuff.gpu_type = GPU_RDNA;
     }
+     else if (strstr(deviceinfo.d_name, "gfx1101"))        // 7800XT
+    {
+        mystuff.gpu_type = GPU_RDNA3;
+    }
     else if (strstr(deviceinfo.d_name, "Cayman")      ||  // 6950, 6970
              strstr(deviceinfo.d_name, "Devastator")  ||  // 7xx0D (iGPUs of A4/6/8/10)
              strstr(deviceinfo.d_name, "Scrapper")    ||  // 7xx0G (iGPUs of A4/6/8/10)

--- a/src/mfakto.ini
+++ b/src/mfakto.ini
@@ -287,8 +287,9 @@ ProgressFormat=%d %T | %C %p%% | %t  %e |   %g  %s  %W%%
 # GPUType=GCN4      Polaris GPUs, such as the Radeon RX 460
 # GPUType=GCN5      14 nm Vega GPUs, such as the Radeon RX Vega 56
 # GPUType=GCNF      7 nm Vega GPUs, namely the Vega 20 series
-# GPUType=RDNA      devices using the RDNA microarchitecture, such as the
+# GPUType=RDNA      devices using the RDNA 1 and 2 microarchitecture, such as the
 #                   Radeon RX 5000 series
+# GPUType=RDNA3      devices using the RDNA 3 microarchitecture
 # GPUType=APU       all APUs. For low-end devices, using GPUType=VLIW5 may
 #                   result in better performance.
 # GPUType=CPU       all CPUs. Used when no GPUs are available; also used when

--- a/src/my_types.h
+++ b/src/my_types.h
@@ -176,6 +176,7 @@ enum GPU_types
   GPU_GCN5,
   GPU_GCNF,  // R VII
   GPU_RDNA,
+  GPU_RDNA3,
   GPU_APU,
   GPU_CPU,
   GPU_NVIDIA,


### PR DESCRIPTION
Put together some performance ordering and elision of kernels with the perftest info found here: https://www.mersenneforum.org/node/11037?p=1058416#post1058416

Ideally we would drill down and try to root cause the errors with these kernels on the architecture, but immediate correctness seems more important. Maybe we can release this as part of 0.16-beta.2?