### PR TITLE
Create assets on release

### DIFF
--- a/.github/workflows/buildrelease.yml
+++ b/.github/workflows/buildrelease.yml
@@ -1,0 +1,118 @@
+name: mfakto release assets
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  Linux:
+    name: Linux
+    runs-on: ubuntu-24.04
+    env:
+      CC: gcc
+      CPP: g++
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup
+      run: |
+        sudo apt-get install -y ocl-icd-opencl-dev pocl-opencl-icd
+    - name: Build
+      run: |
+        make -C src -O -j "$(nproc)" CC=${CC} CPP=${CPP}
+    - name: Test
+      run: |
+        ./mfakto -d 11
+    - name: Create additional release assets
+      run: |
+        tar cvjf mfakto-${{ github.ref_name }}-linux64.tar.bz2 *.cl Changelog-mfakto.txt COPYING datatypes.h mfakto mfakto.ini README-SpecialVersions.txt README.txt tf_debug.h todo.txt
+    - name: Upload additional release assets
+      uses: softprops/action-gh-release@v2
+      with:
+        files: |
+          mfakto-${{ github.ref_name }}-linux64.tar.bz2
+
+
+  WindowsMSVC:
+    name: Windows MSVC
+    runs-on: windows-2022
+    env:
+      OCL_ROOT: "OpenCL-SDK-v2024.05.08-Win-x64"
+      OCL_URL: https://github.com/KhronosGroup/OpenCL-SDK/releases/download/v2024.05.08/OpenCL-SDK-v2024.05.08-Win-x64.zip
+    steps:
+    - uses: actions/checkout@v4
+    - uses: ilammy/msvc-dev-cmd@v1
+    - name: Setup
+      run: |
+        Invoke-WebRequest $env:OCL_URL -OutFile OpenCL-SDK.zip
+        unzip OpenCL-SDK.zip
+        mkdir $env:OCL_ROOT\lib\x86_64
+        cp $env:OCL_ROOT\lib\*.lib $env:OCL_ROOT\lib\x86_64
+    - name: Build
+      run: |
+        msbuild mfaktoVS12.vcxproj /property:OCL_ROOT="$env:OCL_ROOT"
+    - name: Create additional release assets
+      run: |
+        Compress-Archive -DestinationPath mfakto-${{ github.ref_name }}-windows-msvc.zip -CompressionLevel Optimal -Path *.cl, Changelog-mfakto.txt, COPYING, datatypes.h, mfakto.exe, mfakto.ini, README-SpecialVersions.txt, README.txt, tf_debug.h, todo.txt
+    - name: Upload additional release assets
+      uses: softprops/action-gh-release@v2
+      with:
+        files: |
+          mfakto-${{ github.ref_name }}-windows-msvc.zip
+
+  WindowsMSYS2:
+    name: Windows MSYS2
+    runs-on: windows-2022
+    env:
+      CC: gcc
+      CPP: g++
+    steps:
+    - uses: actions/checkout@v4
+    - name: Path Setup
+      run: |
+        echo "C:\msys64\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        echo "C:\msys64\usr\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+    - name: Setup
+      run: |
+        pacman -S --needed --noconfirm mingw-w64-x86_64-opencl-icd mingw-w64-x86_64-opencl-headers
+    - name: Build
+      run: |
+        make -C src -O -j $env:NUMBER_OF_PROCESSORS CC=$env:CC CPP=$env:CPP AMD_APP_INCLUDE="-IC:\msys64\mingw64\include" AMD_APP_LIB="-LC:\msys64\mingw64\lib"
+    - name: Create additional release assets
+      run: |
+        Compress-Archive -DestinationPath mfakto-${{ github.ref_name }}-windows-msys2.zip -CompressionLevel Optimal -Path *.cl, Changelog-mfakto.txt, COPYING, datatypes.h, mfakto.exe, mfakto.ini, README-SpecialVersions.txt, README.txt, tf_debug.h, todo.txt
+    - name: Upload additional release assets
+      uses: softprops/action-gh-release@v2
+      with:
+        files: |
+          mfakto-${{ github.ref_name }}-windows-msys2.zip
+
+  MacOS:
+    name: MacOS
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-13, macos-14]
+      fail-fast: false
+    env:
+      CC: clang
+      CPP: clang++
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup
+      run: |
+        brew install pocl
+    - name: Build
+      run: |
+        make -C src -f Makefile.macOS -j "$(sysctl -n hw.ncpu)" CC=${CC} CPP=${CPP} CFLAGS="-O3 -Wall $(pkg-config --cflags pocl)" LDFLAGS="$(pkg-config --libs pocl)"
+    - name: Test
+      run: |
+        ./mfakto -d 11
+    - name: Create additional release assets
+      run: |
+        tar cvjf mfakto-${{ github.ref_name }}-${{ matrix.os }}.tar.bz2 *.cl Changelog-mfakto.txt COPYING datatypes.h mfakto mfakto.ini README-SpecialVersions.txt README.txt tf_debug.h todo.txt
+    - name: Upload additional release assets
+      uses: softprops/action-gh-release@v2
+      with:
+        files: |
+          mfakto-${{ github.ref_name }}-${{ matrix.os }}.tar.bz2

--- a/.github/workflows/buildrelease.yml
+++ b/.github/workflows/buildrelease.yml
@@ -32,7 +32,6 @@ jobs:
         files: |
           mfakto-${{ github.ref_name }}-linux64.tar.bz2
 
-
   WindowsMSVC:
     name: Windows MSVC
     runs-on: windows-2022
@@ -51,14 +50,15 @@ jobs:
     - name: Build
       run: |
         msbuild mfaktoVS12.vcxproj /property:OCL_ROOT="$env:OCL_ROOT"
-    - name: Create additional release assets
-      run: |
-        Compress-Archive -DestinationPath mfakto-${{ github.ref_name }}-windows-msvc.zip -CompressionLevel Optimal -Path *.cl, Changelog-mfakto.txt, COPYING, datatypes.h, mfakto.exe, mfakto.ini, README-SpecialVersions.txt, README.txt, tf_debug.h, todo.txt
-    - name: Upload additional release assets
-      uses: softprops/action-gh-release@v2
-      with:
-        files: |
-          mfakto-${{ github.ref_name }}-windows-msvc.zip
+# Did not work on GitHub - needs Windows knowledge to fix it
+#    - name: Create additional release assets
+#      run: |
+#        Compress-Archive -DestinationPath mfakto-${{ github.ref_name }}-windows-msvc.zip -CompressionLevel Optimal -Path *.cl, Changelog-mfakto.txt, COPYING, datatypes.h, mfakto.exe, mfakto.ini, README-SpecialVersions.txt, README.txt, tf_debug.h, todo.txt
+#    - name: Upload additional release assets
+#      uses: softprops/action-gh-release@v2
+#      with:
+#        files: |
+#          mfakto-${{ github.ref_name }}-windows-msvc.zip
 
   WindowsMSYS2:
     name: Windows MSYS2


### PR DESCRIPTION
On creating tags for releases this change will introduce an automatic build on Linux, Windows and MacOS to build the needed release assets to use mfakto on this operating systems.

Some information:
- I used the v0.16-beta2 Windows build as a base for building the assets
- Creating the Windows version with VS is failing with an error message which I don't know to solve as I has no access to a Windows system. If I get the way how to build them I can include the solution in this pull request or it must be later adjusted.

Edit: 
- You can look at https://github.com/henning-gerhardt/mfakto/releases/tag/v0.0.1 which assets are created on tag release.
- Release tags must start with a beginning `v` to trigger release asset building but this can be adjusted in `buildrelease.yml` file