### PR TITLE
Build artifact and release assets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,13 +40,13 @@ jobs:
     - name: Create artifact and release asset
       if: startsWith(github.ref, 'refs/tags/')
       run: |
-        tar cvjf mfakto-${{ github.ref_name }}-linux64.tar.bz2 *.cl Changelog-mfakto.txt COPYING datatypes.h mfakto mfakto.ini README-SpecialVersions.txt README.txt tf_debug.h todo.txt
+        tar cvjf mfakto-linux64.tar.bz2 *.cl Changelog-mfakto.txt COPYING datatypes.h mfakto mfakto.ini README-SpecialVersions.txt README.txt tf_debug.h todo.txt
     - name: Upload release assets on release
       uses: softprops/action-gh-release@v2
       if: startsWith(github.ref, 'refs/tags/')
       with:
         files: |
-          mfakto-${{ github.ref_name }}-linux64.tar.bz2
+          mfakto-linux64.tar.bz2
 
   WindowsMSVC:
     name: Windows MSVC
@@ -69,7 +69,7 @@ jobs:
     - name: Create artifact and release asset
       run: |
         Copy-Item -Path Changelog-mfakto.txt, COPYING, README-SpecialVersions.txt, README.txt, todo.txt, src/mfakto.ini -Destination x64/Debug/
-        Compress-Archive -DestinationPath mfakto-${{ github.ref_name }}-windows-msvc.zip -CompressionLevel Optimal -Path x64/Debug/*
+        Compress-Archive -DestinationPath mfakto-windows-msvc.zip -CompressionLevel Optimal -Path x64/Debug/*
     - name: Upload build artifact
       uses: actions/upload-artifact@v4
       with:
@@ -80,7 +80,7 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/')
       with:
         files: |
-          mfakto-${{ github.ref_name }}-windows-msvc.zip
+          mfakto-windows-msvc.zip
 
   WindowsMSYS2:
     name: Windows MSYS2
@@ -118,13 +118,13 @@ jobs:
     - name: Create artifact and release asset
       if: startsWith(github.ref, 'refs/tags/')
       run: |
-        Compress-Archive -DestinationPath mfakto-${{ github.ref_name }}-windows-msys2.zip -CompressionLevel Optimal -Path *.cl, Changelog-mfakto.txt, COPYING, datatypes.h, mfakto.exe, mfakto.ini, README-SpecialVersions.txt, README.txt, tf_debug.h, todo.txt
+        Compress-Archive -DestinationPath mfakto-windows-msys2.zip -CompressionLevel Optimal -Path *.cl, Changelog-mfakto.txt, COPYING, datatypes.h, mfakto.exe, mfakto.ini, README-SpecialVersions.txt, README.txt, tf_debug.h, todo.txt
     - name: Upload release assets on release
       uses: softprops/action-gh-release@v2
       if: startsWith(github.ref, 'refs/tags/')
       with:
         files: |
-           mfakto-${{ github.ref_name }}-windows-msys2.zip
+           mfakto-windows-msys2.zip
 
   MacOS:
     name: MacOS
@@ -165,10 +165,10 @@ jobs:
     - name: Create artifact and release asset
       if: startsWith(github.ref, 'refs/tags/')
       run: |
-        tar cvjf mfakto-${{ github.ref_name }}-${{ matrix.os }}.tar.bz2 *.cl Changelog-mfakto.txt COPYING datatypes.h mfakto mfakto.ini README-SpecialVersions.txt README.txt tf_debug.h todo.txt
+        tar cvjf mfakto-${{ matrix.os }}.tar.bz2 *.cl Changelog-mfakto.txt COPYING datatypes.h mfakto mfakto.ini README-SpecialVersions.txt README.txt tf_debug.h todo.txt
     - name: Upload release assets on release
       uses: softprops/action-gh-release@v2
       if: startsWith(github.ref, 'refs/tags/')
       with:
         files: |
-          mfakto-${{ github.ref_name }}-${{ matrix.os }}.tar.bz2
+          mfakto-${{ matrix.os }}.tar.bz2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,16 +65,16 @@ jobs:
         cp $env:OCL_ROOT\lib\*.lib $env:OCL_ROOT\lib\x86_64
     - name: Build
       run: |
-        msbuild mfaktoVS12.vcxproj /property:OCL_ROOT="$env:OCL_ROOT"
+        msbuild mfaktoVS12.vcxproj /property:OCL_ROOT="$env:OCL_ROOT" /property:Configuration=Release
     - name: Create artifact and release asset
       run: |
-        Copy-Item -Path Changelog-mfakto.txt, COPYING, README-SpecialVersions.txt, README.txt, todo.txt, src/mfakto.ini -Destination x64/Debug/
-        Compress-Archive -DestinationPath mfakto-windows-msvc.zip -CompressionLevel Optimal -Path x64/Debug/*
+        Copy-Item -Path Changelog-mfakto.txt, COPYING, README-SpecialVersions.txt, README.txt, todo.txt, src/mfakto.ini -Destination x64/Release/
+        Compress-Archive -DestinationPath mfakto-windows-msvc.zip -CompressionLevel Optimal -Path x64/Release/*
     - name: Upload build artifact
       uses: actions/upload-artifact@v4
       with:
         name: mfakto-windows-msvc
-        path: x64/Debug/
+        path: x64/Release/
     - name: Upload release asset on release
       uses: softprops/action-gh-release@v2
       if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,16 +141,16 @@ jobs:
     - name: Setup
       run: |
         brew install pocl
-    - name: Build GitHub development version
+    - name: Build with pocl
       run: |
         make -C src -j "$(sysctl -n hw.ncpu)" CC=${CC} CPP=${CPP} AMD_APP_INCLUDE="$(pkg-config --cflags pocl)" AMD_APP_LIB="$(pkg-config --libs pocl)"
     - name: Test
       run: |
         ./mfakto -d 11
-    - name: Cleanup build for user artifact
+    - name: Cleanup build
       run: |
         make -C src clean
-    - name: Build user artifact without pocl dependency
+    - name: Build for native OpenCL
       run: |
         make -C src -j "$(sysctl -n hw.ncpu)" CC=${CC} CPP=${CPP}
     - name: Upload build artifact

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,31 @@ jobs:
     - name: Test
       run: |
         ./mfakto -d 11
+    - name: Upload build artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: mfakto-linux64
+        path: |
+          *.cl
+          Changelog-mfakto.txt
+          COPYING
+          datatypes.h
+          mfakto
+          mfakto.ini
+          README-SpecialVersions.txt
+          README.txt
+          tf_debug.h
+          todo.txt
+    - name: Create artifact and release asset
+      if: startsWith(github.ref, 'refs/tags/')
+      run: |
+        tar cvjf mfakto-${{ github.ref_name }}-linux64.tar.bz2 *.cl Changelog-mfakto.txt COPYING datatypes.h mfakto mfakto.ini README-SpecialVersions.txt README.txt tf_debug.h todo.txt
+    - name: Upload release assets on release
+      uses: softprops/action-gh-release@v2
+      if: startsWith(github.ref, 'refs/tags/')
+      with:
+        files: |
+          mfakto-${{ github.ref_name }}-linux64.tar.bz2
 
   WindowsMSVC:
     name: Windows MSVC
@@ -41,6 +66,21 @@ jobs:
     - name: Build
       run: |
         msbuild mfaktoVS12.vcxproj /property:OCL_ROOT="$env:OCL_ROOT"
+    - name: Create artifact and release asset
+      run: |
+        Copy-Item -Path Changelog-mfakto.txt, COPYING, README-SpecialVersions.txt, README.txt, todo.txt, src/mfakto.ini -Destination x64/Debug/
+        Compress-Archive -DestinationPath mfakto-${{ github.ref_name }}-windows-msvc.zip -CompressionLevel Optimal -Path x64/Debug/*
+    - name: Upload build artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: mfakto-windows-msvc
+        path: x64/Debug/
+    - name: Upload release asset on release
+      uses: softprops/action-gh-release@v2
+      if: startsWith(github.ref, 'refs/tags/')
+      with:
+        files: |
+          mfakto-${{ github.ref_name }}-windows-msvc.zip
 
   WindowsMSYS2:
     name: Windows MSYS2
@@ -60,6 +100,31 @@ jobs:
     - name: Build
       run: |
         make -C src -O -j $env:NUMBER_OF_PROCESSORS CC=$env:CC CPP=$env:CPP AMD_APP_INCLUDE="-IC:\msys64\mingw64\include" AMD_APP_LIB="-LC:\msys64\mingw64\lib"
+    - name: Upload build artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: mfakto-windows-msys2
+        path: |
+          *.cl
+          Changelog-mfakto.txt
+          COPYING
+          datatypes.h
+          mfakto.exe
+          mfakto.ini
+          README-SpecialVersions.txt
+          README.txt
+          tf_debug.h
+          todo.txt
+    - name: Create artifact and release asset
+      if: startsWith(github.ref, 'refs/tags/')
+      run: |
+        Compress-Archive -DestinationPath mfakto-${{ github.ref_name }}-windows-msys2.zip -CompressionLevel Optimal -Path *.cl, Changelog-mfakto.txt, COPYING, datatypes.h, mfakto.exe, mfakto.ini, README-SpecialVersions.txt, README.txt, tf_debug.h, todo.txt
+    - name: Upload release assets on release
+      uses: softprops/action-gh-release@v2
+      if: startsWith(github.ref, 'refs/tags/')
+      with:
+        files: |
+           mfakto-${{ github.ref_name }}-windows-msys2.zip
 
   MacOS:
     name: MacOS
@@ -82,3 +147,28 @@ jobs:
     - name: Test
       run: |
         ./mfakto -d 11
+    - name: Upload build artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: mfakto-${{ matrix.os }}
+        path: |
+          *.cl
+          Changelog-mfakto.txt
+          COPYING
+          datatypes.h
+          mfakto
+          mfakto.ini
+          README-SpecialVersions.txt
+          README.txt
+          tf_debug.h
+          todo.txt
+    - name: Create artifact and release asset
+      if: startsWith(github.ref, 'refs/tags/')
+      run: |
+        tar cvjf mfakto-${{ github.ref_name }}-${{ matrix.os }}.tar.bz2 *.cl Changelog-mfakto.txt COPYING datatypes.h mfakto mfakto.ini README-SpecialVersions.txt README.txt tf_debug.h todo.txt
+    - name: Upload release assets on release
+      uses: softprops/action-gh-release@v2
+      if: startsWith(github.ref, 'refs/tags/')
+      with:
+        files: |
+          mfakto-${{ github.ref_name }}-${{ matrix.os }}.tar.bz2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,12 +141,18 @@ jobs:
     - name: Setup
       run: |
         brew install pocl
-    - name: Build
+    - name: Build GitHub development version
       run: |
         make -C src -j "$(sysctl -n hw.ncpu)" CC=${CC} CPP=${CPP} AMD_APP_INCLUDE="$(pkg-config --cflags pocl)" AMD_APP_LIB="$(pkg-config --libs pocl)"
     - name: Test
       run: |
         ./mfakto -d 11
+    - name: Cleanup build for user artifact
+      run: |
+        make -C src clean
+    - name: Build user artifact without pocl dependency
+      run: |
+        make -C src -j "$(sysctl -n hw.ncpu)" CC=${CC} CPP=${CPP}
     - name: Upload build artifact
       uses: actions/upload-artifact@v4
       with:


### PR DESCRIPTION
This pull request may superseed #12.

Instead of running two workflows and two possible different builds the created files from the CI workflow are used to create even the release builds assets. Benefit is that every build now create all artifacts assets for every operation system so even without a release every one on every supported operation system can try the most recent version out without the need to build mfakto itself.

I discovered too how to build the artifact and release assert on windows-msvc. This can even be pack ported to #12 if two independent build workflows should be used.

I could only test the created Linux based assets in a successful way, so Windows and MacOS should be tested who can access them.

Edit:
- release assets are accessable under https://github.com/henning-gerhardt/mfakto/releases/tag/v0.0.2