### PR TITLE
barrett15_74: add workaround for MacOS bug

### DIFF
--- a/src/barrett15.cl
+++ b/src/barrett15.cl
@@ -1827,10 +1827,11 @@ ff = 1/f as float, needed in div_192_96().
   a.d1 = SUB_COND(-tmp75.d1, a.d0 > 0);
   a.d2 = SUB_COND(-tmp75.d2, a.d1 > 0x7FFF);
   a.d3 = SUB_COND(-tmp75.d3, a.d2 > 0x7FFF);
-  a.d4 = SUB_COND(mad24(bb.d5, 32768u, bb.d4) - tmp75.d4, a.d3 > 0x7FFF) & 0xFFFF;  // keep one extra bit
+  a.d4 = SUB_COND(mad24(bb.d5, 32768u, bb.d4) - tmp75.d4, a.d3 > 0x7FFF);
   a.d1 &= 0x7FFF;
   a.d2 &= 0x7FFF;
   a.d3 &= 0x7FFF;
+  a.d4 &= 0x1FFFF;  // keep 2 extra bits
 
 #if (TRACE_KERNEL > 3)
     if (tid==TRACE_TID) printf((__constant char *)"cl_barrett15_74: b=%x:%x:%x:%x:%x - tmp = %x:%x:%x:%x:%x (a)\n",

--- a/src/mfakto.cpp
+++ b/src/mfakto.cpp
@@ -645,10 +645,11 @@ void set_gpu_type()
     {
       mystuff.gpu_type = GPU_GCN3;   // these cards have improved int32 performance over the previous GCNs, making for a changed kernel selection
     }
-    else if (strstr(deviceinfo.d_name, "Ellesmere")  ||    // RX 470/480/570/580/590
-             strstr(deviceinfo.d_name, "gfx804")     ||    // RX 550
-             strstr(deviceinfo.d_name, "Lexa")       ||    // small GCN 4.0 - not tested, only assumption
-             strstr(deviceinfo.d_name, "Baffin")           // small GCN 4.0 - not tested, only assumption
+    else if (strstr(deviceinfo.d_name, "Ellesmere")      ||    // RX 470/480/570/580/590
+             strstr(deviceinfo.d_name, "gfx804")         ||    // RX 550
+             strstr(deviceinfo.d_name, "Radeon Pro 560") ||    // Baffin, used on Macs
+             strstr(deviceinfo.d_name, "Lexa")           ||    // small GCN 4.0 - not tested, only assumption
+             strstr(deviceinfo.d_name, "Baffin")               // small GCN 4.0 - not tested, only assumption
             )
     {
       mystuff.gpu_type = GPU_GCN4;


### PR DESCRIPTION
barrett15_74: add workaround for MacOS bug

This fixes failures in barrett15_74 on MacOS 14 with Radeon Pro 560.

Keep 2 extra bits for a.d4 before loop just like it's done later inside
the loop. It may not be necessary mathematically, but it prevents an
optimization bug that turns a.d4 into a random number on MacOS.

Recognize "Radeon Pro 560" that exhibits the issue as GCN4.