### PR TITLE
Simplify Windows MSYS2 build by using the msys2/setup-msys2 action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,18 +48,23 @@ jobs:
     env:
       CC: gcc
       CPP: g++
+    defaults:
+      run:
+        shell: msys2 {0}
     steps:
+    - uses: msys2/setup-msys2@v2
+      with:
+        update: true
+        msystem: mingw64
+        pacboy: >-
+          gcc:p
+          make:p
+          opencl-headers:p
+          opencl-icd:p
     - uses: actions/checkout@v4
-    - name: Path Setup
-      run: |
-        echo "C:\msys64\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-        echo "C:\msys64\usr\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-    - name: Setup
-      run: |
-        pacman -S --needed --noconfirm mingw-w64-x86_64-opencl-icd mingw-w64-x86_64-opencl-headers
     - name: Build
       run: |
-        make -C src -O -j $env:NUMBER_OF_PROCESSORS CC=$env:CC CPP=$env:CPP AMD_APP_INCLUDE="-IC:\msys64\mingw64\include" AMD_APP_LIB="-LC:\msys64\mingw64\lib"
+        mingw32-make -C src -O -j $NUMBER_OF_PROCESSORS CC=$CC CPP=$CPP
 
   MacOS:
     name: MacOS


### PR DESCRIPTION
The original implementation had several problems:
* The installation path `C:\msys64\` was hardcoded in multiple places
* `AMD_APP_INCLUDE` and `AMD_APP_LIB` were misused for MinGW system includes and libraries

The new implementation brings in advantages:
* Dependency on an action maintained maintained by MSYS2 developers: https://github.com/msys2/setup-msys2
* Easy to change the environment (mingw64, ucrt64, clang64)
* Using pacboy for environment-specific packages (e.g. `mingw-w64-x86_64-opencl-icd` becomes `opencl-icd`)
* Using bash instead of powershell (`$env:CC` becomes `$CC`)

Note that `mingw32-make` is the name of all environment-specific make executables, not just for 32-bit environments. See https://packages.msys2.org/packages/mingw-w64-x86_64-make