### PR TITLE
mfakto.ini changes (StopAfterFactor=1, Stages=0)

### DIFF
--- a/src/mfakto.ini
+++ b/src/mfakto.ini
@@ -214,7 +214,7 @@ Stages=1
 #
 # Default: StopAfterFactor=2
 
-StopAfterFactor=2
+StopAfterFactor=1
 
 
 # possible values for PrintMode:

--- a/src/mfakto.ini
+++ b/src/mfakto.ini
@@ -212,7 +212,7 @@ Stages=0
 #     when Stages is enabled.
 # 2 = Stop at the current class after finding a factor.
 #
-# Default: StopAfterFactor=2
+# Default: StopAfterFactor=1
 
 StopAfterFactor=1
 

--- a/src/mfakto.ini
+++ b/src/mfakto.ini
@@ -203,7 +203,7 @@ CheckpointDelay=300
 #
 # Default: Stages=1
 
-Stages=1
+Stages=0
 
 
 # possible values for StopAfterFactor:


### PR DESCRIPTION
StopAfterFactor=1 (not 2!!) really should be the default, it always has been for mfaktc. Stopping after finding a factor (and not finishing the bitlevel) makes for messy data.

Stages=0 is now the default setting in mfaktc, should probably be unified across the two programs.