### PR TITLE
Add LegacyResultsTXT option, deprecate legacy results.txt

### DIFF
--- a/src/mfakto.ini
+++ b/src/mfakto.ini
@@ -184,6 +184,13 @@ LogFile=mfakto.log
 
 Checkpoints=1
 
+# LegacyResultsTxt can be used to enable deprecated results.txt output
+# 0: Do not write the results in deprecated format to results.txt
+# 1: Output the results in deprecated format to results.txt
+#
+# Default: LegacyResultsTxt=0
+LegacyResultsTxt=0
+
 
 # CheckpointDelay is the minimum time in seconds between checkpoint writes.
 # Only evaluated when Checkpoints=1

--- a/src/my_types.h
+++ b/src/my_types.h
@@ -293,30 +293,31 @@ typedef struct _mystuff_t
   cl_uint  small_exp;
   cl_uint  print_timestamp;
   cl_uint  quit;
-  cl_ulong cpu_mask;         /* CPU affinity mask for the siever thread */
-  cl_int   verbosity;        /* -1 = uninitialized, 0 = reduced number of screen printfs, 1= default, >= 2 = some additional printfs */
+  cl_ulong cpu_mask;           /* CPU affinity mask for the siever thread */
+  cl_int   verbosity;          /* -1 = uninitialized, 0 = reduced number of screen printfs, 1= default, >= 2 = some additional printfs */
   cl_int   logging;
+  cl_int   legacy_results_txt; /* 0 = output to results.txt disabled (default), 1 = output to results.txt enabled */
   cl_uint  selftestsize;
-  cl_uint  force_rebuild;    /* 1: delete the previous binfile */
+  cl_uint  force_rebuild;      /* 1: delete the previous binfile */
 
-  stats_t  stats;            /* stats for the status line */
+  stats_t  stats;              /* stats for the status line */
 
-  char workfile[51];         /* allow filenames up to 50 chars... */
-  char inifile[51];	         /* allow filenames up to 50 chars... */
+  char workfile[51];           /* allow filenames up to 50 chars... */
+  char inifile[51];	       /* allow filenames up to 50 chars... */
   char resultfile[51];
   char jsonresultfile[51];
   char logfile[51];
   FILE *logfileptr;
-  char V5UserID[51];         /* primenet V5UserID and ComputerID */
-  char ComputerID[51];       /* currently only used for screen/result output */
+  char V5UserID[51];           /* primenet V5UserID and ComputerID */
+  char ComputerID[51];         /* currently only used for screen/result output */
   char assignment_key[MAX_LINE_LENGTH + 1]; /* the assignment ID */
-  char factors_string[500];            /* store factors in global state */
-  char CompileOptions[151];  /* additional compile options */
-  char binfile[51];          /* compiled kernels file to use, empty if not desired */
+  char factors_string[500];    /* store factors in global state */
+  char CompileOptions[151];    /* additional compile options */
+  char binfile[51];            /* compiled kernels file to use, empty if not desired */
 
-  cl_uint override_v;        /* override INI file when setting verbosity */
+  cl_uint override_v;          /* override INI file when setting verbosity */
 
-}mystuff_t;			/* FIXME: proper name needed */
+}mystuff_t;		       /* FIXME: proper name needed */
 
 typedef struct
 {

--- a/src/output.c
+++ b/src/output.c
@@ -432,7 +432,8 @@ void getOSJSON(char* string) {
 
 
 void print_result_line(mystuff_t *mystuff, int factorsfound)
-/* printf the final result line (STDOUT and resultfile) */
+// printf the final result line to STDOUT and to resultfile if LegacyResultsTxt set to 1.
+// Prints JSON string to the jsonresultfile for Mersenne numbers as well.
 {
   char UID[110]; /* 50 (V5UserID) + 50 (ComputerID) + 8 + spare */
   char aidjson[111];
@@ -483,8 +484,11 @@ void print_result_line(mystuff_t *mystuff, int factorsfound)
 
   if(mystuff->mode == MODE_NORMAL)
   {
-    txtresultfile = fopen_and_lock(mystuff->resultfile, "a");
-    if(mystuff->print_timestamp == 1)print_timestamp(txtresultfile);
+    if (mystuff->legacy_results_txt == 1)
+    {
+      txtresultfile = fopen_and_lock(mystuff->resultfile, "a");
+      if(mystuff->print_timestamp == 1)print_timestamp(txtresultfile);
+    }
     jsonresultfile = fopen_and_lock(mystuff->jsonresultfile, "a");
   }
   bool partialresult = (mystuff->mode == MODE_NORMAL) && (mystuff->stats.class_counter < max_class_number);
@@ -509,8 +513,11 @@ void print_result_line(mystuff_t *mystuff, int factorsfound)
   }
   if(mystuff->mode == MODE_NORMAL)
   {
-    fprintf(txtresultfile, "%s%s\n", UID, txtstring);
-    unlock_and_fclose(txtresultfile);
+    if (mystuff->legacy_results_txt == 1)
+    {
+      fprintf(txtresultfile, "%s%s\n", UID, txtstring);
+      unlock_and_fclose(txtresultfile);
+    }
     fprintf(jsonresultfile, "%s\n", jsonstring);
     unlock_and_fclose(jsonresultfile);
   }
@@ -520,7 +527,7 @@ void print_result_line(mystuff_t *mystuff, int factorsfound)
 void print_factor(mystuff_t *mystuff, int factor_number, char *factor, double bits)
 {
   char UID[110]; /* 50 (V5UserID) + 50 (ComputerID) + 8 + spare */
-  FILE *resultfile = NULL;
+  FILE *txtresultfile = NULL;
   unsigned int max_class_number;
 
   if (mystuff->more_classes)  max_class_number = 960;
@@ -531,10 +538,10 @@ void print_factor(mystuff_t *mystuff, int factor_number, char *factor, double bi
   else
     UID[0]=0;
 
-  if(mystuff->mode == MODE_NORMAL)
+  if(mystuff->mode == MODE_NORMAL && mystuff->legacy_results_txt == 1)
   {
-    resultfile = fopen_and_lock(mystuff->resultfile, "a");
-    if(mystuff->print_timestamp == 1 && factor_number == 0)print_timestamp(resultfile);
+    txtresultfile = fopen_and_lock(mystuff->resultfile, "a");
+    if(mystuff->print_timestamp == 1 && factor_number == 0)print_timestamp(txtresultfile);
   }
 
   if(factor_number < 10)
@@ -544,9 +551,9 @@ void print_factor(mystuff_t *mystuff, int factor_number, char *factor, double bi
       if(mystuff->printmode == 1 && factor_number == 0)logprintf(mystuff, "\n");
       logprintf(mystuff, "M%u has a factor: %s (%f bits, %f GHz-d)\n", mystuff->exponent, factor, bits, mystuff->stats.ghzdays);
     }
-    if(mystuff->mode == MODE_NORMAL)
+    if(mystuff->mode == MODE_NORMAL && mystuff->legacy_results_txt == 1)
     {
-      fprintf(resultfile, "%sM%u has a factor: %s [TF:%d:%d%s:%s %s]\n",
+      fprintf(txtresultfile, "%sM%u has a factor: %s [TF:%d:%d%s:%s %s]\n",
         UID, mystuff->exponent, factor, mystuff->bit_min, mystuff->bit_max_stage,
         ((mystuff->stopafterfactor == 2) && (mystuff->stats.class_counter < max_class_number)) ? "*" : "" ,
         MFAKTO_VERSION, mystuff->stats.kernelname);
@@ -555,10 +562,13 @@ void print_factor(mystuff_t *mystuff, int factor_number, char *factor, double bi
   else /* factor_number >= 10 */
   {
     if(mystuff->mode != MODE_SELFTEST_SHORT)      printf("M%u: %d additional factors not shown\n",      mystuff->exponent, factor_number-10);
-    if(mystuff->mode == MODE_NORMAL)fprintf(resultfile,"%sM%u: %d additional factors not shown\n", UID, mystuff->exponent, factor_number-10);
+    if(mystuff->mode == MODE_NORMAL && mystuff->legacy_results_txt == 1)
+    {
+      fprintf(txtresultfile,"%sM%u: %d additional factors not shown\n", UID, mystuff->exponent, factor_number-10);
+    }
   }
 
-  if(mystuff->mode == MODE_NORMAL)unlock_and_fclose(resultfile);
+  if(mystuff->mode == MODE_NORMAL && mystuff->legacy_results_txt == 1)unlock_and_fclose(txtresultfile);
 }
 
 

--- a/src/read_config.c
+++ b/src/read_config.c
@@ -745,6 +745,25 @@ int read_config(mystuff_t *mystuff)
 
 /*****************************************************************************/
 
+  if(my_read_int(mystuff->inifile, "LegacyResultsTxt", &i))
+  {
+    logprintf(mystuff, "WARNING: Cannot read LegacyResultsTxt from mfakto.ini, set to 0 by default\n");
+    i=0;
+  }
+  else if(i != 0 && i != 1)
+  {
+    logprintf(mystuff, "WARNING: LegacyResultsTxt must be 0 or 1, set to 0 by default\n");
+    i=0;
+  }
+  if(mystuff->verbosity >= 1)
+  {
+    if(i == 0)logprintf(mystuff, "  LegacyResultsTxt          no\n");
+    else      logprintf(mystuff, "  LegacyResultsTxt          yes\n");
+  }
+  mystuff->legacy_results_txt = i;
+
+/*****************************************************************************/
+
   if(my_read_int(mystuff->inifile, "VectorSize", &i))
   {
     logprintf(mystuff, "WARNING: Cannot read VectorSize from INI file, set to 4 by default\n");


### PR DESCRIPTION
This commit adds the LegacyResultsTXT option to mfakto.ini, disabled by default (set to 0). When disabled, mfakto will no longer write output to results.txt in the legacy format, which has been superseded by the JSON format.

Ported from mfaktc:
https://github.com/primesearch/mfaktc/pull/36

[This port was requested](https://www.mersenneforum.org/node/9313?p=1079099#post1079099) by @JamesHeinrich, but I don't use mfakto and can't test these changes. Someone should test and confirm it works before merging this PR.