### PR TITLE
Change hardcoded INI file name to generic mention

### DIFF
--- a/src/read_config.c
+++ b/src/read_config.c
@@ -747,7 +747,7 @@ int read_config(mystuff_t *mystuff)
 
   if(my_read_int(mystuff->inifile, "LegacyResultsTxt", &i))
   {
-    logprintf(mystuff, "WARNING: Cannot read LegacyResultsTxt from mfakto.ini, set to 0 by default\n");
+    logprintf(mystuff, "WARNING: Cannot read LegacyResultsTxt from INI file, set to 0 by default\n");
     i=0;
   }
   else if(i != 0 && i != 1)


### PR DESCRIPTION
As it was ported from mfaktc, where filenames aren't configurable. To avoid dealing with input validation & buffer memory allocation just use more generic phrasing here without exact filename.

Ref: https://www.mersenneforum.org/node/11037?p=1079151#post1079151