### PR TITLE
fix recent macOS build issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,8 +165,8 @@ jobs:
     env:
       CC: clang
       CPP: clang++
-      # needed for Homebrew 4.6.4 and above to work
-      HOMEBREW_DEVELOPER: "1"
+      # needed for Homebrew 4.6.4 and above
+      HOMEBREW_DEVELOPER: '1'
     steps:
     - uses: actions/checkout@v4
 
@@ -174,22 +174,20 @@ jobs:
     #   run: |
     #     brew install pocl
 
-    # workaround for PoCL issues, see https://github.com/actions/runner-images/issues/12775#issuecomment-3226624291
+    # workaround for Homebrew bug - see https://github.com/Homebrew/brew/issues/20568
+    # to do: remove this once the macOS runners have been updated to use
+    # Homebrew 4.6.8 or above
+    - name: Update Homebrew to latest stable version
+      run: brew update
+
+    # workaround for PoCL 7.0[.x] issues - see https://github.com/actions/runner-images/issues/12775#issuecomment-3226624291
     - name: Install PoCL 6.0.1
       run: |
-        echo "Installing PoCL 6.0.1..."
         pocl_commit="165dae39781a8150f265d2fae6ea036964dbaad8"
         pocl_rb_link="https://raw.githubusercontent.com/Homebrew/homebrew-core/$pocl_commit/Formula/p/pocl.rb"
         mkdir -p /tmp/pocl
         curl -fsSL "$pocl_rb_link" -o /tmp/pocl/pocl.rb
         brew install --formula /tmp/pocl/pocl.rb
-
-    - name: Verify PoCL installation
-      run: |
-        echo "PATH=$PATH"
-        poclcc --version || echo "PoCL compiler not found"
-        brew info pocl
-    # end workaround
 
     - name: Build with PoCL
       run: |


### PR DESCRIPTION
mfakto builds for macOS were not working correctly due to recent changes in dependencies:

* PoCL 7.0 is known not to compile certain OpenCL applications correctly - see https://github.com/actions/runner-images/issues/12775#issuecomment-3219867978
* Homebrew 4.6.5 ~ 4.6.7 could not install LLVM due to an incorrect path lookup -  see https://github.com/Homebrew/brew/issues/20568

This PR provides a temporary fix for the build failures by adding the following actions to the workflow file:

* Update Homebrew to the latest stable version (should be removed once the macOS runners have been updated to use version 4.6.8 or above)
* Roll back to PoCL 6.0.1

I also added line breaks in the workflow file to improve readability.