### PR TITLE
remove references to `AllowSleep`

### DIFF
--- a/src/mfakto.ini
+++ b/src/mfakto.ini
@@ -288,17 +288,6 @@ ProgressFormat=%d %T | %C %p%% | %t  %e |   %g  %s  %W%%
 #ProgressFormat=[%d %T] M%M[%l-%u]: %p% %C/4620,%c/960 %g %ts | %e | %n | %rM/s |%s | %wus = %W%, %U@%H
 
 
-# allow the CPU to sleep when idle?
-# 0 = Do not sleep while waiting for the GPU
-# 1 = The CPU can sleep for a short time while waiting for the GPU
-# Currently unused. mfakto does not use busy waiting and is always waiting for
-# an event to signal thread completion.
-#
-# Default: AllowSleep=1
-
-# AllowSleep=1
-
-
 # Different GPUs may perform better with certain kernels.
 # Here, you can tell mfakto how to optimize them.
 #

--- a/src/my_types.h
+++ b/src/my_types.h
@@ -289,7 +289,6 @@ typedef struct _mystuff_t
 
   cl_uint  vectorsize;
   cl_uint  printmode;
-//  cl_uint  allowsleep;    // not used in mfakto (yet)
   cl_uint  small_exp;
   cl_uint  print_timestamp;
   cl_uint  quit;

--- a/src/read_config.c
+++ b/src/read_config.c
@@ -367,27 +367,6 @@ int read_config(mystuff_t *mystuff)
     #endif
 
     mystuff->cpu_mask = ul;
-  /*****************************************************************************/
-  /* not used in mfakto (yet)
-    if(my_read_int(mystuff->inifile, "AllowSleep", &i))
-    {
-      logprintf(mystuff, "Warning: Cannot read AllowSleep from inifile, set to 0 by default\n");
-      i=0;
-    }
-    else if(i != 0 && i != 1)
-    {
-      logprintf(mystuff, "Warning: AllowSleep must be 0 or 1, set to 0 by default\n");
-      i=0;
-    }
-    if(mystuff->verbosity >= 1)
-    {
-      if(i == 0)logprintf(mystuff, "  AllowSleep                no\n");
-      else      logprintf(mystuff, "  AllowSleep                yes\n");
-    }
-    mystuff->allowsleep = i;
-    */
-/*****************************************************************************/
-
   }
   else // SieveOnGPU
   {


### PR DESCRIPTION
`AllowSleep` is used for CPU sieving and is not implemented in mfakto. It has determined that such a feature would not be useful. `todo.txt` states:

> +NO+ - AllowSleep + not needed due to GPU sieving +

I figured it was best to remove all such references from the INI file and code comments.