### PR TITLE
remove temporary step to update Homebrew

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,12 +174,6 @@ jobs:
     #   run: |
     #     brew install pocl
 
-    # workaround for Homebrew bug - see https://github.com/Homebrew/brew/issues/20568
-    # to do: remove this once the macOS runners have been updated to use
-    # Homebrew 4.6.8 or above
-    - name: Update Homebrew to latest stable version
-      run: brew update
-
     # workaround for PoCL 7.0[.x] issues - see https://github.com/actions/runner-images/issues/12775#issuecomment-3226624291
     - name: Install PoCL 6.0.1
       run: |


### PR DESCRIPTION
Removed the temporary step to update Homebrew as macOS runners have been updated to include a fixed version. This should slightly reduce the workflow run time.