### PR TITLE
bump version to `0.16-beta.3`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,7 @@ vcpkg_installed/
 
 # device-specific files
 *.ckp
-*.ckp.bu
+*.ckp.*
 *.log
 results.txt
 results.json.txt

--- a/README.txt
+++ b/README.txt
@@ -1,4 +1,4 @@
-** Preface for mfakto 0.16-beta.2 **
+** Preface for mfakto 0.16-beta.3 **
 
 This is a developmental version of mfakto. It has been verified to produce
 correct results. However, there may be bugs and incomplete features, and

--- a/mfaktoVS12.vcxproj
+++ b/mfaktoVS12.vcxproj
@@ -157,7 +157,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <Version>0.14</Version>
+      <Version>0.16</Version>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>OpenCL.lib</AdditionalDependencies>
     </Link>
@@ -190,7 +190,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <Version>0.15</Version>
+      <Version>0.16</Version>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>OpenCL.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
@@ -234,7 +234,7 @@
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <Version>0.14</Version>
+      <Version>0.16</Version>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>OpenCL.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
@@ -277,7 +277,7 @@
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <Version>0.14</Version>
+      <Version>0.16</Version>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>OpenCL.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>

--- a/src/barrett.cl
+++ b/src/barrett.cl
@@ -16,7 +16,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with mfaktc (mfakto).  If not, see <http://www.gnu.org/licenses/>.
 
-Version 0.15
+Version 0.16
 */
 
 /****************************************

--- a/src/barrett15.cl
+++ b/src/barrett15.cl
@@ -16,7 +16,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with mfaktc (mfakto).  If not, see <http://www.gnu.org/licenses/>.
 
-Version 0.15
+Version 0.16
 */
 
 /****************************************

--- a/src/common.cl
+++ b/src/common.cl
@@ -16,7 +16,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with mfaktc (mfakto).  If not, see <http://www.gnu.org/licenses/>.
 
-Version 0.15
+Version 0.16
 */
 
 /*

--- a/src/datatypes.h
+++ b/src/datatypes.h
@@ -16,7 +16,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with mfaktc (mfakto).  If not, see <http://www.gnu.org/licenses/>.
 
-Version 0.15
+Version 0.16
 
 */
 

--- a/src/gpusieve.cl
+++ b/src/gpusieve.cl
@@ -16,7 +16,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with mfaktc (mfakto).  If not, see <http://www.gnu.org/licenses/>.
 
-Version 0.15
+Version 0.16
 */
 
 

--- a/src/mfakto_Kernels.cl
+++ b/src/mfakto_Kernels.cl
@@ -16,9 +16,10 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with mfaktc (mfakto).  If not, see <http://www.gnu.org/licenses/>.
 
-Version 0.15
+Version 0.16
 
 */
+
 /*
  All OpenCL kernels for mfakto Trial-Factoring
 

--- a/src/montgomery.cl
+++ b/src/montgomery.cl
@@ -16,7 +16,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with mfaktc (mfakto).  If not, see <http://www.gnu.org/licenses/>.
 
-Version 0.15
+Version 0.16
 */
 
 /*

--- a/src/mul24.cl
+++ b/src/mul24.cl
@@ -16,7 +16,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with mfaktc (mfakto).  If not, see <http://www.gnu.org/licenses/>.
 
-Version 0.15
+Version 0.16
 */
 
 /* This file will be included TWICE by the main kernel file, once with

--- a/src/params.h
+++ b/src/params.h
@@ -105,7 +105,7 @@ than an equal SIEVE_SIZE_LIMIT #define.
 Please discuss with the community before making changes to version numbers!
 */
 
-#define SHORT_MFAKTO_VERSION "0.16-beta.2"
+#define SHORT_MFAKTO_VERSION "0.16-beta.3"
 
 #ifdef _MSC_VER
   #define MFAKTO_VERSION "mfakto " SHORT_MFAKTO_VERSION "-Win"


### PR DESCRIPTION
Bumped the version to `0.16-beta.3` per James' suggestion: https://mersenneforum.org/node/11037?p=1088474#post1088474

Also updated `.gitignore` to include bad checkpoint files.