### PR TITLE
Revert "simplify cmp_int96()"

### DIFF
--- a/src/output.c
+++ b/src/output.c
@@ -475,13 +475,15 @@ static int cmp_int96(const void* p1, const void* p2)
 {
     int96* a = (int96*)p1, * b = (int96*)p2;
 
-    if (a->d2 > b->d2 || a->d1 > b->d1 || a->d0 > b->d0) {
-        return 1;
-    }
-    if (a->d2 < b->d2 || a->d1 < b->d1 || a->d0 < b->d0) {
-        return -1;
-    }
+    // clang-format off
+    if (a->d2 > b->d2)      return 1;
+    if (a->d2 < b->d2)      return -1;
+    if (a->d1 > b->d1)      return 1;
+    if (a->d1 < b->d1)      return -1;
+    if (a->d0 > b->d0)      return 1;
+    if (a->d0 < b->d0)      return -1;
     return 0;
+    // clang-format on
 }
 
 void print_result_line(mystuff_t *mystuff, int factorsfound)


### PR DESCRIPTION
This reverts commit 3cfd3b939ef456caf9eca32eca4afb6eaa5f3b76 (PR: https://github.com/primesearch/mfakto/pull/36).

The change introduced by that commit modified the behavior of `cmp_int96()`, causing it to produce incorrect results. It's not the same to compare all 32-bit words at once as it is to compare them in order from high to low words, as was done originally. After the change, it could return `a > b` if **any** word in `a` is greater than the corresponding word in `b` (OR logic in the condition), even if the full 96-bit value of `a` is actually less than `b`.

Originally, the function used a few "if" statements comparing from high to low words (`d2 -> d1 -> d0`). The indents in the original mfaktc function reflect this intended stepwise comparison:

```C
static int cmp_int96(const void *p1, const void *p2)
{
    int96 *a = (int96 *)p1, *b = (int96 *)p2;

    // clang-format off
    if (a->d2 > b->d2)      return 1;
    else if (a->d2 < b->d2) return -1;
    else
        if (a->d1 > b->d1)      return 1;
        else if (a->d1 < b->d1) return -1;
        else
            if (a->d0 > b->d0)      return 1;
            else if (a->d0 < b->d0) return -1;
            else                    return 0;
    // clang-format on
}
```