### PR TITLE
General improvements (2025-09-28)

### DIFF
--- a/Changelog-mfakto.txt
+++ b/Changelog-mfakto.txt
@@ -7,10 +7,9 @@ new features:
 - implemented runtime logging
   - set Logging=1 in the INI file to enable
 - merged in checksum generation code from mfaktc (thanks to James Heinrich)
-  - to accommodate this change, mfakto has been updated to use the same
-    checkpoint format as mfaktc 0.23.x
-    - the checksums for the checkpoints and JSON output are now generated with
-      the same seed
+  - removed a redundant checksum generation function from checkpoint.c
+  - to accommodate this change, the checkpoint format has been updated
+    - stored factors are no longer enclosed in quotes
   - additional code contributions and bug fixes by Danny Chia
 
 enhancements:

--- a/Changelog-mfakto.txt
+++ b/Changelog-mfakto.txt
@@ -7,8 +7,11 @@ new features:
 - implemented runtime logging
   - set Logging=1 in the INI file to enable
 - merged in checksum generation code from mfaktc (thanks to James Heinrich)
-  - updated mfakto to use the same checkpoint format as mfaktc 0.23.x (thanks
-    to Danny Chia)
+  - to accommodate this change, mfakto has been updated to use the same
+    checkpoint format as mfaktc 0.23.x
+    - the checksums for the checkpoints and JSON output are now generated with
+      the same seed
+  - additional code contributions and bug fixes by Danny Chia
 
 enhancements:
 - added RDNA 3 support

--- a/Changelog-mfakto.txt
+++ b/Changelog-mfakto.txt
@@ -8,8 +8,9 @@ new features:
   - set Logging=1 in the INI file to enable
 - merged in checksum generation code from mfaktc (thanks to James Heinrich)
   - removed a redundant checksum generation function from checkpoint.c
-  - to accommodate this change, the checkpoint format has been updated
-    - stored factors are no longer enclosed in quotes
+  - to accommodate this change, the checkpoint format has been updated to no
+    longer put quotes around stored factors. mfakto should still be able to
+    read checkpoints from a previous version
   - additional code contributions and bug fixes by Danny Chia
 
 enhancements:

--- a/Changelog-mfakto.txt
+++ b/Changelog-mfakto.txt
@@ -51,6 +51,7 @@ other changes:
     logging to results.txt
 - merged in James Heinrich's changes to mfaktc.ini and re-organized mfakto.ini
   to be more user-friendly
+- removed references to unnecessary AllowSleep option
 - removed inaccurate throughput information from program output
 - macOS is now detected as "macOS" rather than the kernel name "Darwin"
 

--- a/README-SpecialVersions.txt
+++ b/README-SpecialVersions.txt
@@ -11,9 +11,10 @@ mfakto-64k :  Optimized for CPUs with 64 kB of L1 cache
 
 mfakto-var :  Enables configuration of SieveSize via mfakto.ini
 
-              Useful for determining the optimal SieveSize value, but is about
-              1-3% slower compared to versions in which the sieve size is
-              fixed at compile time.
+              Useful for determining the optimal SieveSize value when sieving
+              on the CPU, but is about 1-3% slower compared to versions with
+              the sieve size fixed at compile time, for the same SieveSize
+              value.
 
               Comment out the SIEVE_SIZE_LIMIT define in params.h to create
               this build.

--- a/README-SpecialVersions.txt
+++ b/README-SpecialVersions.txt
@@ -1,16 +1,32 @@
-The SpecialVersions_x64.zip and x32.zip packages contain mfakto.exe files
-compiled for special purposes:
+Different mfakto variants can be compiled for special purposes. Here are the
+three most common configurations:
 
-mfakto-64k :  A binary optimized for 64k L1 cache. This is useful for most AMD
-              CPUs, but also for Intel CPUs when going to high SievePrimes
-              values (>100k).
-mfakto-var :  Compiled to allow SieveSize configuration via mfakto.ini. Most
-              useful for testing which SieveSize is optimal, but 1-3% slower
-              sieving than the fixed-size compiled files (for the same SieveSize).
-mfakto-pi  :  For each block, the OpenCL performance counters are read and
-              displayed. This allows for accurate measuring of transfer and
-              kernel execution speed. Intended for performance tests.
+mfakto-64k :  Optimized for CPUs with 64 kB of L1 cache
 
-Apart from these settings, these binaries are the same as the corresponding 
-normal package, which is optimized for 32k L1 cache (most Intel CPUs).
+              Useful for AMD CPUs, but also Intel CPUs when the SievePrimes
+              value is very high (around 100,000 or above).
+
+              Set the SIEVE_SIZE_LIMIT define to 64 in params.h to compile
+              this version.
+
+mfakto-var :  Enables configuration of SieveSize via mfakto.ini
+
+              Useful for determining the optimal SieveSize value, but is about
+              1-3% slower compared to versions in which the sieve size is
+              fixed at compile time.
+
+              Comment out the SIEVE_SIZE_LIMIT define in params.h to create
+              this build.
+
+mfakto-pi  :  Displays the OpenCL performance information for each block
+
+              Enables accurate measurement of certain metrics, such as the
+              kernel execution speed and data transfer rate. Intended for
+              performance tests.
+
+              Uncomment the CL_PERFORMANCE_INFO define in params.h to
+              compile.
+
+Otherwise, these versions are the same as the normal mfakto executable and are
+optimized for CPUs with 32 kB of L1 cache.
 

--- a/README-SpecialVersions.txt
+++ b/README-SpecialVersions.txt
@@ -13,8 +13,7 @@ mfakto-var :  Enables configuration of SieveSize via mfakto.ini
 
               Useful for determining the optimal SieveSize value when sieving
               on the CPU, but is about 1-3% slower compared to versions with
-              the sieve size fixed at compile time, for the same SieveSize
-              value.
+              the same sieve size fixed at compile time.
 
               Comment out the SIEVE_SIZE_LIMIT define in params.h to create
               this build.

--- a/src/checkpoint.c
+++ b/src/checkpoint.c
@@ -108,7 +108,7 @@ int checkpoint_read(unsigned int exp, int bit_min, int bit_max, unsigned int *cu
 {
   FILE *f;
   int ret=0,i,chksum;
-  char ckp_buffer[MAX_BUFFER_LENGTH] = { 0 }, cur_buffer[MAX_BUFFER_LENGTH], * ptr, * ptr2, filename[20], filename_save[32], version[81], factors_buffer[MAX_FACTOR_BUFFER_LENGTH];
+  char ckp_buffer[MAX_BUFFER_LENGTH] = { 0 }, cur_buffer[MAX_BUFFER_LENGTH], *ptr, *ptr2, filename[20], filename_save[32], version[81], factors_buffer[MAX_FACTOR_BUFFER_LENGTH];
 
   *cur_class=-1;
   *num_factors=0;

--- a/src/kbhit.cpp
+++ b/src/kbhit.cpp
@@ -1,5 +1,5 @@
 // simulate _kbhit() on Linux
-// taken from http://linux-sxs.org/programming/kbhit.html
+// taken from https://web.archive.org/web/20200224015457/http://linux-sxs.org/programming/kbhit.html
 
 #ifndef _WIN32
 

--- a/src/output.c
+++ b/src/output.c
@@ -219,19 +219,25 @@ int96 parse_dez96(char* str)
     return result;
 }
 
-void print_timestamp(FILE *outfile)
+void print_timestamp(FILE* outfile)
 {
-  char* ptr;
-  const time_t now = time(NULL);
-  static time_t previous_time=0;
+    char* ptr;
+    const time_t now = time(NULL);
+    static time_t previous_time = 0;
 
-  if (previous_time + 5 < now) // have at least 5 seconds between successive time stamps in the results file
-  {
-    ptr = asctime(gmtime(&now));
-    ptr[24] = '\0'; // cut off the newline
-    fprintf(outfile, "[%s]\n", ptr);
-    previous_time = now;
-  }
+    if (previous_time + 5 < now) // have at least 5 seconds between successive time stamps in the results file
+    {
+        ptr = asctime(gmtime(&now));
+        if (ptr) {
+            ptr[24] = '\0'; // cut off the newline
+        }
+        else {
+            printf("Warning: could not determine current time, asctime() returned null pointer\n");
+            ptr = "Wed Jan  1 00:00:00 2025";
+        }
+        fprintf(outfile, "[%s]\n", ptr);
+        previous_time = now;
+    }
 }
 
 
@@ -396,12 +402,22 @@ void print_status_line(mystuff_t *mystuff)
       }
       else if(mystuff->stats.progressformat[i+1] == '%')
       {
-        buffer[index++] = '%';
+          if (index < 0) {
+              printf("Warning: invalid buffer index %d\n", index);
+          }
+          else {
+              buffer[index++] = '%';
+          }
       }
       else /* '%' + unknown format character -> just print "%<character>" */
       {
-        buffer[index++] = '%';
-        --i; // advance i only by 1, with the +=2 below. This way, we don't run over the end of the string if the last char is '%'
+          if (index < 0) {
+              printf("Warning: invalid buffer index %d\n", index);
+          }
+          else {
+              buffer[index++] = '%';
+              --i; // advance i only by 1, with the +=2 below. This way, we don't run over the end of the string if the last char is '%'
+          }
       }
 
       i += 2;
@@ -426,8 +442,13 @@ void print_status_line(mystuff_t *mystuff)
     index += sprintf(buffer + index, "\n");
   }
 
-  buffer[index] = 0;
-  logprintf(mystuff, "%s", buffer);
+  if (index < 0) {
+      printf("Warning: invalid buffer index %d\n", index);
+  }
+  else {
+      buffer[index] = 0;
+      logprintf(mystuff, "%s", buffer);
+  }
 }
 
 void get_utc_timestamp(char* timestamp)

--- a/src/output.c
+++ b/src/output.c
@@ -26,7 +26,6 @@ along with mfaktc.  If not, see <http://www.gnu.org/licenses/>.
 #include <string.h>
 #include <stdlib.h>
 #include "crc.h"
-#include "string.h"
 #include "params.h"
 #include "my_types.h"
 #include "output.h"

--- a/src/output.c
+++ b/src/output.c
@@ -496,15 +496,16 @@ static int cmp_int96(const void* p1, const void* p2)
 {
     int96* a = (int96*)p1, * b = (int96*)p2;
 
-    // clang-format off
+    // do not combine the if-statements, they are intended to be executed in
+    // the given order
     if (a->d2 > b->d2)      return 1;
     if (a->d2 < b->d2)      return -1;
     if (a->d1 > b->d1)      return 1;
     if (a->d1 < b->d1)      return -1;
     if (a->d0 > b->d0)      return 1;
     if (a->d0 < b->d0)      return -1;
+
     return 0;
-    // clang-format on
 }
 
 void print_result_line(mystuff_t *mystuff, int factorsfound)

--- a/src/params.h
+++ b/src/params.h
@@ -236,6 +236,7 @@ The following lines define the min, default and max value.
 #define MAX_DEZ_96_STRING_LENGTH       30 // max value of int96 (unsigned) has 29 digits + 1 byte for NUL
 
 #define MAX_FACTOR_BUFFER_LENGTH       MAX_FACTORS_PER_JOB * MAX_DEZ_96_STRING_LENGTH
+#define MAX_BUFFER_LENGTH              MAX_FACTOR_BUFFER_LENGTH + 100
 
 #define GHZDAYS_MAGIC_TF_TOP           0.016968 // magic constant for TF to 65 bits and above
 #define GHZDAYS_MAGIC_TF_MID           0.017832 // magic constant for 63 and 64 bits

--- a/src/parse.h
+++ b/src/parse.h
@@ -40,10 +40,8 @@ struct ASSIGNMENT
 	unsigned int exponent;
 	int bit_min;
 	int bit_max;
-	char assignment_key[MAX_LINE_LENGTH+1];	// optional assignment key....
-	char comment[MAX_LINE_LENGTH+1];	// optional comment.
-						// if it has a newline at the end, it was on a line by itself preceding the assignment.
-						// otherwise, it followed the assignment on the same line.
+	char assignment_key[MAX_LINE_LENGTH + 1];	// optional assignment key
+	char comment[MAX_LINE_LENGTH + 1];	// optional comment
 };
 
 

--- a/src/tf_debug.h
+++ b/src/tf_debug.h
@@ -16,7 +16,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with mfaktc (mfakto).  If not, see <http://www.gnu.org/licenses/>.
 
-Version 0.13
+Version 0.16
 
 */
 


### PR DESCRIPTION
Some more improvements for mfakto:
* fixed several MSVC warnings
* removed a duplicate `#include "string.h"`
* renamed some variables in `checkpoint.c` to be more descriptive, and converted hard-coded buffer sizes to a macro
* clarified many code comments
* updated `README-SpecialVersions.txt`
  * the special builds have not been distributed in a while, so the readme no longer mentions the .zip files
  * provided instructions on compiling the special versions
  * removed the part about most Intel CPUs having 32 kB of L1 cache as modern CPUs generally have much larger L1 caches nowadays