### PR TITLE
bump version to `0.16.0-beta.4` and switch to semantic versioning

### DIFF
--- a/Changelog-mfakto.txt
+++ b/Changelog-mfakto.txt
@@ -1,4 +1,4 @@
-version 0.16
+version 0.16.0
 ==============================
 - includes features merged in from mfaktc 0.23.x and 0.24.0
 
@@ -54,6 +54,7 @@ other changes:
 - removed references to unnecessary AllowSleep option
 - removed inaccurate throughput information from program output
 - macOS is now detected as "macOS" rather than the kernel name "Darwin"
+- switched to the semantic versioning scheme
 
 version 0.15
 ==============================

--- a/README.txt
+++ b/README.txt
@@ -1,4 +1,4 @@
-** Preface for mfakto 0.16-beta.3 **
+** Preface for mfakto 0.16.0-beta.4 **
 
 This is a developmental version of mfakto. It has been verified to produce
 correct results. However, there may be bugs and incomplete features, and

--- a/mfaktoVS12.vcxproj
+++ b/mfaktoVS12.vcxproj
@@ -157,7 +157,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <Version>0.16</Version>
+      <Version>0.16.0</Version>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>OpenCL.lib</AdditionalDependencies>
     </Link>
@@ -190,7 +190,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <Version>0.16</Version>
+      <Version>0.16.0</Version>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>OpenCL.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
@@ -234,7 +234,7 @@
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <Version>0.16</Version>
+      <Version>0.16.0</Version>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>OpenCL.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
@@ -277,7 +277,7 @@
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <Version>0.16</Version>
+      <Version>0.16.0</Version>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>OpenCL.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>

--- a/src/barrett.cl
+++ b/src/barrett.cl
@@ -16,7 +16,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with mfaktc (mfakto).  If not, see <http://www.gnu.org/licenses/>.
 
-Version 0.16
+Version 0.16.0
 */
 
 /****************************************

--- a/src/barrett15.cl
+++ b/src/barrett15.cl
@@ -16,7 +16,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with mfaktc (mfakto).  If not, see <http://www.gnu.org/licenses/>.
 
-Version 0.16
+Version 0.16.0
 */
 
 /****************************************

--- a/src/common.cl
+++ b/src/common.cl
@@ -16,7 +16,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with mfaktc (mfakto).  If not, see <http://www.gnu.org/licenses/>.
 
-Version 0.16
+Version 0.16.0
 */
 
 /*

--- a/src/datatypes.h
+++ b/src/datatypes.h
@@ -16,7 +16,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with mfaktc (mfakto).  If not, see <http://www.gnu.org/licenses/>.
 
-Version 0.16
+Version 0.16.0
 
 */
 

--- a/src/gpusieve.cl
+++ b/src/gpusieve.cl
@@ -16,7 +16,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with mfaktc (mfakto).  If not, see <http://www.gnu.org/licenses/>.
 
-Version 0.16
+Version 0.16.0
 */
 
 

--- a/src/mfakto.ini
+++ b/src/mfakto.ini
@@ -1,4 +1,4 @@
-# Version 0.16
+# Version 0.16.0
 
 ##
 ## User settings that are commonly modified:

--- a/src/mfakto_Kernels.cl
+++ b/src/mfakto_Kernels.cl
@@ -16,7 +16,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with mfaktc (mfakto).  If not, see <http://www.gnu.org/licenses/>.
 
-Version 0.16
+Version 0.16.0
 
 */
 

--- a/src/montgomery.cl
+++ b/src/montgomery.cl
@@ -16,7 +16,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with mfaktc (mfakto).  If not, see <http://www.gnu.org/licenses/>.
 
-Version 0.16
+Version 0.16.0
 */
 
 /*

--- a/src/mul24.cl
+++ b/src/mul24.cl
@@ -16,7 +16,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with mfaktc (mfakto).  If not, see <http://www.gnu.org/licenses/>.
 
-Version 0.16
+Version 0.16.0
 */
 
 /* This file will be included TWICE by the main kernel file, once with

--- a/src/params.h
+++ b/src/params.h
@@ -105,7 +105,7 @@ than an equal SIEVE_SIZE_LIMIT #define.
 Please discuss with the community before making changes to version numbers!
 */
 
-#define SHORT_MFAKTO_VERSION "0.16-beta.3"
+#define SHORT_MFAKTO_VERSION "0.16.0-beta.4"
 
 #ifdef _MSC_VER
   #define MFAKTO_VERSION "mfakto " SHORT_MFAKTO_VERSION "-Win"

--- a/src/tf_debug.h
+++ b/src/tf_debug.h
@@ -16,7 +16,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with mfaktc (mfakto).  If not, see <http://www.gnu.org/licenses/>.
 
-Version 0.16
+Version 0.16.0
 
 */
 


### PR DESCRIPTION
Per discussion with @JamesHeinrich here: https://mersenneforum.org/node/11037?p=1091405#post1091405