### PR TITLE
Suppress "File was not locked!" debug message

### DIFF
--- a/src/filelocking.c
+++ b/src/filelocking.c
@@ -192,7 +192,6 @@ int unlock_and_fclose(FILE *f)
   }
   if (f)
   {
-    //fprintf(stderr, "File was not locked!\n");
     ret = fclose(f);
   }
   return ret;


### PR DESCRIPTION
Remove debugging output to match mfatkc https://github.com/primesearch/mfaktc/pull/91

The change on line 41 I think is due to a mismatched LF/CRLF lineend that Github Desktop auto-corrected.