### PR TITLE
group Dependabot updates into a single pull request to reduce PR spam

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Dependabot currently creates a separate pull request for each updated action. This change groups the updates into a single PR to reduce spam.