### PR TITLE
Added separate CI and CD workflows

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,188 @@
+name: mfakto CD
+
+on:
+  push:
+    tags:
+      - '*'
+  workflow_dispatch:
+
+jobs:
+  Linux:
+    name: Linux
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v7
+
+    - name: Build
+      run: |
+        docker run --rm -i -v "$GITHUB_WORKSPACE:/workspace" -w /workspace centos:7 bash -s <<'EOF'
+        set -e -o pipefail
+        sed -i '/^mirrorlist/d;/^#baseurl=/{s|^#||;s|/mirror|/vault|;}' /etc/yum.repos.d/CentOS*.repo
+        # yum update -y
+        yum install -y centos-release-scl epel-release
+        sed -i 's|/centos/7/|/centos/7.6.1810/|g;/^mirrorlist/d;/^# *baseurl=/{s|^# *||;s|/mirror|/vault|;}' /etc/yum.repos.d/CentOS-SCLo-*.repo
+        yum install -y devtoolset-6-gcc-c++ devtoolset-6-libstdc++-static make ocl-icd-devel
+
+        source /opt/rh/devtoolset-6/enable
+        gcc --version
+        ldd --version
+
+        make -C src -j "$(nproc)"
+        EOF
+
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v7
+      with:
+        name: mfakto-linux64
+        path: |
+          *.cl
+          Changelog-mfakto.txt
+          COPYING
+          datatypes.h
+          mfakto
+          mfakto.ini
+          README-SpecialVersions.txt
+          README.txt
+          tf_debug.h
+          todo.txt
+
+    - name: Create artifacts and release assets
+      if: startsWith(github.ref, 'refs/tags/')
+      run: |
+        tar -cvjf mfakto-linux64.tar.bz2 *.cl Changelog-mfakto.txt COPYING datatypes.h mfakto mfakto.ini README-SpecialVersions.txt README.txt tf_debug.h todo.txt
+    - name: Release
+      uses: softprops/action-gh-release@v3
+      if: startsWith(github.ref, 'refs/tags/')
+      with:
+        files: |
+          mfakto-linux64.tar.bz2
+
+  WindowsMSVC:
+    name: Windows MSVC
+    runs-on: windows-2022
+    steps:
+    - uses: actions/checkout@v7
+    - uses: step-security/msvc-dev-cmd@v1
+
+    - name: Install dependencies
+      run: |
+        vcpkg integrate install --vcpkg-root=c:\vcpkg
+
+    - name: Build
+      run: |
+        msbuild mfaktoVS12.vcxproj /p:Configuration=Release
+
+    - name: Create artifacts and release assets
+      run: |
+        Copy-Item -Path Changelog-mfakto.txt, COPYING, README-SpecialVersions.txt, README.txt, todo.txt -Destination x64/Release/
+        Compress-Archive -DestinationPath mfakto-windows-msvc.zip -CompressionLevel Optimal -Path x64/Release/*
+
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v7
+      with:
+        name: mfakto-windows-msvc
+        path: x64/Release/
+
+    - name: Release
+      uses: softprops/action-gh-release@v3
+      if: startsWith(github.ref, 'refs/tags/')
+      with:
+        files: |
+          mfakto-windows-msvc.zip
+
+  WindowsMSYS2:
+    name: Windows MSYS2
+    runs-on: windows-latest
+    env:
+      PACKAGE_PREFIX: mingw-w64-x86_64-
+    steps:
+    - uses: actions/checkout@v7
+
+    - name: Configure paths
+      run: |
+        echo "C:\msys64\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        echo "C:\msys64\usr\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+    - name: Install dependencies
+      run: |
+        pacman -S --noconfirm "${env:PACKAGE_PREFIX}opencl-icd" "${env:PACKAGE_PREFIX}opencl-headers"
+
+    - name: Build
+      run: |
+        make -C src -O -j $env:NUMBER_OF_PROCESSORS AMD_APP_INCLUDE="-IC:\msys64\mingw64\include" AMD_APP_LIB="-LC:\msys64\mingw64\lib"
+
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v7
+      with:
+        name: mfakto-windows-msys2
+        path: |
+          *.cl
+          Changelog-mfakto.txt
+          COPYING
+          datatypes.h
+          mfakto.exe
+          mfakto.ini
+          README-SpecialVersions.txt
+          README.txt
+          tf_debug.h
+          todo.txt
+
+    - name: Create artifacts and release assets
+      if: startsWith(github.ref, 'refs/tags/')
+      run: |
+        Compress-Archive -DestinationPath mfakto-windows-msys2.zip -CompressionLevel Optimal -Path *.cl, Changelog-mfakto.txt, COPYING, datatypes.h, mfakto.exe, mfakto.ini, README-SpecialVersions.txt, README.txt, tf_debug.h, todo.txt
+
+    - name: Release
+      uses: softprops/action-gh-release@v3
+      if: startsWith(github.ref, 'refs/tags/')
+      with:
+        files: |
+           mfakto-windows-msys2-${{ matrix.cc }}.zip
+
+  macOS:
+    name: macOS
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, macos-26-intel]
+      fail-fast: false
+    env:
+      # Used by CI workflow file. For mapping from "runs-on" / "os" to architecture, see:
+      # https://docs.github.com/en/actions/how-tos/write-workflows/choose-where-workflows-run/choose-the-runner-for-a-job#standard-github-hosted-runners-for-public-repositories
+      SELFARCH: ${{ endsWith(matrix.os, '-intel') && 'x64' || 'ARM64' }}
+      # Just because we use a new builder doesn't mean we don't want the build to run on an older OS
+      MACOSX_DEPLOYMENT_TARGET: 11.0.0
+    steps:
+    - uses: actions/checkout@v7
+
+    - name: Build
+      run: |
+        make -C src -j "$(sysctl -n hw.ncpu)"
+
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v7
+      with:
+        name: mfakto-macos-${{ env.SELFARCH }}
+        path: |
+          *.cl
+          Changelog-mfakto.txt
+          COPYING
+          datatypes.h
+          mfakto
+          mfakto.ini
+          README-SpecialVersions.txt
+          README.txt
+          tf_debug.h
+          todo.txt
+
+    - name: Create artifacts and release assets
+      if: startsWith(github.ref, 'refs/tags/')
+      run: |
+        tar -cvjf mfakto-macos-${{ env.SELFARCH }}.tar.bz2 *.cl Changelog-mfakto.txt COPYING datatypes.h mfakto mfakto.ini README-SpecialVersions.txt README.txt tf_debug.h todo.txt
+
+    - name: Release
+      uses: softprops/action-gh-release@v3
+      if: startsWith(github.ref, 'refs/tags/')
+      with:
+        files: |
+          mfakto-macos-${{ env.SELFARCH }}.tar.bz2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,15 +16,21 @@ on:
       - 'reopened'
       - 'synchronize'
       - 'ready_for_review'
-  workflow_dispatch:
+  schedule:
+    - cron: '0 0 1 * *'
 
 jobs:
   Linux:
     name: Linux
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-22.04, ubuntu-24.04, ubuntu-26.04, ubuntu-22.04-arm, ubuntu-24.04-arm, ubuntu-26.04-arm]
+        cc: [gcc, clang]
+      fail-fast: false
     env:
-      CC: gcc
-      CPP: g++
+      CC: ${{ matrix.cc }}
+      CXX: ${{ matrix.cc == 'gcc' && 'g++' || 'clang++' }}
     steps:
     - uses: actions/checkout@v7
 
@@ -34,16 +40,18 @@ jobs:
 
     - name: Build
       run: |
-        make -C src -O -j "$(nproc)" CC=${CC} CPP=${CPP}
+        make -C src -O -j "$(nproc)" DEBUG=1
 
     - name: Test
+      if: ${{ !startsWith(matrix.os, 'ubuntu-22.04') }}
       run: |
         ./mfakto -d 11
 
     - name: Upload build artifacts
       uses: actions/upload-artifact@v7
+      if: always()
       with:
-        name: mfakto-linux64
+        name: mfakto-linux64-${{ matrix.os }}-${{ matrix.cc }}
         path: |
           *.cl
           Changelog-mfakto.txt
@@ -55,17 +63,6 @@ jobs:
           README.txt
           tf_debug.h
           todo.txt
-
-    - name: Create artifacts and release assets
-      if: startsWith(github.ref, 'refs/tags/')
-      run: |
-        tar cvjf mfakto-linux64.tar.bz2 *.cl Changelog-mfakto.txt COPYING datatypes.h mfakto mfakto.ini README-SpecialVersions.txt README.txt tf_debug.h todo.txt
-    - name: Release
-      uses: softprops/action-gh-release@v3
-      if: startsWith(github.ref, 'refs/tags/')
-      with:
-        files: |
-          mfakto-linux64.tar.bz2
 
   WindowsMSVC:
     name: Windows MSVC
@@ -80,32 +77,32 @@ jobs:
 
     - name: Build
       run: |
-        msbuild mfaktoVS12.vcxproj /property:Configuration=Release
+        msbuild mfaktoVS12.vcxproj /p:Configuration=Debug
 
     - name: Create artifacts and release assets
       run: |
-        Copy-Item -Path Changelog-mfakto.txt, COPYING, README-SpecialVersions.txt, README.txt, todo.txt -Destination x64/Release/
-        Compress-Archive -DestinationPath mfakto-windows-msvc.zip -CompressionLevel Optimal -Path x64/Release/*
+        Copy-Item -Path Changelog-mfakto.txt, COPYING, README-SpecialVersions.txt, README.txt, todo.txt -Destination x64/Debug/
+        Compress-Archive -DestinationPath mfakto-windows-msvc.zip -CompressionLevel Optimal -Path x64/Debug/*
 
     - name: Upload build artifacts
       uses: actions/upload-artifact@v7
+      if: always()
       with:
         name: mfakto-windows-msvc
-        path: x64/Release/
-
-    - name: Release
-      uses: softprops/action-gh-release@v3
-      if: startsWith(github.ref, 'refs/tags/')
-      with:
-        files: |
-          mfakto-windows-msvc.zip
+        path: x64/Debug/
 
   WindowsMSYS2:
     name: Windows MSYS2
-    runs-on: windows-2022
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest] # windows-11-arm
+        cc: [gcc, clang]
+      fail-fast: false
     env:
-      CC: gcc
-      CPP: g++
+      CC: ${{ matrix.cc }}
+      CXX: ${{ matrix.cc == 'gcc' && 'g++' || 'clang++' }}
+      PACKAGE_PREFIX: mingw-w64-${{ endsWith(matrix.os, '-arm') && 'clang-aarch64' || 'x86_64' }}-
     steps:
     - uses: actions/checkout@v7
 
@@ -116,16 +113,22 @@ jobs:
 
     - name: Install dependencies
       run: |
-        pacman -S --needed --noconfirm mingw-w64-x86_64-opencl-icd mingw-w64-x86_64-opencl-headers
+        pacman -S --noconfirm "${env:PACKAGE_PREFIX}opencl-icd" "${env:PACKAGE_PREFIX}opencl-headers"
+
+    - name: Install Clang
+      if: matrix.cc == 'clang'
+      run: |
+        pacman -S --noconfirm "${env:PACKAGE_PREFIX}clang"
 
     - name: Build
       run: |
-        make -C src -O -j $env:NUMBER_OF_PROCESSORS CC=$env:CC CPP=$env:CPP AMD_APP_INCLUDE="-IC:\msys64\mingw64\include" AMD_APP_LIB="-LC:\msys64\mingw64\lib"
+        make -C src -O -j $env:NUMBER_OF_PROCESSORS DEBUG=1 AMD_APP_INCLUDE="-IC:\msys64\mingw64\include" AMD_APP_LIB="-LC:\msys64\mingw64\lib"
 
     - name: Upload build artifacts
       uses: actions/upload-artifact@v7
+      if: always()
       with:
-        name: mfakto-windows-msys2
+        name: mfakto-windows-msys2-${{ endsWith(matrix.os, '-arm') && 'ARM64' || 'x64' }}-${{ matrix.cc }}
         path: |
           *.cl
           Changelog-mfakto.txt
@@ -138,33 +141,16 @@ jobs:
           tf_debug.h
           todo.txt
 
-    - name: Create artifacts and release assets
-      if: startsWith(github.ref, 'refs/tags/')
-      run: |
-        Compress-Archive -DestinationPath mfakto-windows-msys2.zip -CompressionLevel Optimal -Path *.cl, Changelog-mfakto.txt, COPYING, datatypes.h, mfakto.exe, mfakto.ini, README-SpecialVersions.txt, README.txt, tf_debug.h, todo.txt
-
-    - name: Release
-      uses: softprops/action-gh-release@v3
-      if: startsWith(github.ref, 'refs/tags/')
-      with:
-        files: |
-           mfakto-windows-msys2.zip
-
   macOS:
     name: macOS
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-14, macos-15-intel]
+        os: [macos-14, macos-15-intel, macos-15, macos-26-intel, macos-26]
       fail-fast: false
     env:
-      CC: clang
-      CPP: clang++
       # needed for Homebrew 4.6.4 and above
       HOMEBREW_DEVELOPER: '1'
-      # Used by CI workflow file. For mapping from "runs-on" / "os" to architecture, see:
-      # https://docs.github.com/en/actions/how-tos/write-workflows/choose-where-workflows-run/choose-the-runner-for-a-job#standard-github-hosted-runners-for-public-repositories
-      SELFARCH: ${{ matrix.os == 'macos-15-intel' && 'X64' || 'ARM64' }}
       # Just because we use a new builder doesn't mean we don't want the build to run on an older OS
       MACOSX_DEPLOYMENT_TARGET: 11.0.0
     steps:
@@ -185,10 +171,13 @@ jobs:
 
     - name: Build with PoCL
       run: |
-        make -C src -j "$(sysctl -n hw.ncpu)" CC=${CC} CPP=${CPP} AMD_APP_INCLUDE="$(pkg-config --cflags pocl)" AMD_APP_LIB="$(pkg-config --libs pocl)"
+        make -C src -j "$(sysctl -n hw.ncpu)" DEBUG=1 AMD_APP_INCLUDE="$(pkg-config --cflags pocl)" AMD_APP_LIB="$(pkg-config --libs pocl)"
 
     - name: Test
       run: |
+        sdkroot=$(xcrun --sdk macosx --show-sdk-path)
+        export SDKROOT=$sdkroot
+        export LIBRARY_PATH="$sdkroot/usr/lib${LIBRARY_PATH:+:$LIBRARY_PATH}"
         ./mfakto -d 11
 
     - name: Clean up build
@@ -197,12 +186,13 @@ jobs:
 
     - name: Build for native OpenCL
       run: |
-        make -C src -j "$(sysctl -n hw.ncpu)" CC=${CC} CPP=${CPP}
+        make -C src -j "$(sysctl -n hw.ncpu)"
 
     - name: Upload build artifacts
       uses: actions/upload-artifact@v7
+      if: always()
       with:
-        name: mfakto-macos-${{ env.SELFARCH }}
+        name: mfakto-${{ matrix.os }}-${{ endsWith(matrix.os, '-intel') && 'x64' || 'ARM64' }}
         path: |
           *.cl
           Changelog-mfakto.txt
@@ -214,15 +204,3 @@ jobs:
           README.txt
           tf_debug.h
           todo.txt
-
-    - name: Create artifacts and release assets
-      if: startsWith(github.ref, 'refs/tags/')
-      run: |
-        tar cvjf mfakto-macos-${{ env.SELFARCH }}.tar.bz2 *.cl Changelog-mfakto.txt COPYING datatypes.h mfakto mfakto.ini README-SpecialVersions.txt README.txt tf_debug.h todo.txt
-
-    - name: Release
-      uses: softprops/action-gh-release@v3
-      if: startsWith(github.ref, 'refs/tags/')
-      with:
-        files: |
-          mfakto-macos-${{ env.SELFARCH }}.tar.bz2

--- a/mfaktoVS12.vcxproj
+++ b/mfaktoVS12.vcxproj
@@ -149,7 +149,7 @@
     <ClCompile>
       <PrecompiledHeader>
       </PrecompiledHeader>
-      <WarningLevel>Level1</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
@@ -182,7 +182,7 @@
     <ClCompile>
       <PrecompiledHeader>
       </PrecompiledHeader>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
@@ -213,29 +213,22 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <WarningLevel>Level1</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <Optimization>MaxSpeed</Optimization>
-      <FunctionLevelLinking>false</FunctionLevelLinking>
-      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
       </AdditionalIncludeDirectories>
-      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
-      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
-      <OmitFramePointers>true</OmitFramePointers>
-      <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
       <ExceptionHandling>Sync</ExceptionHandling>
       <BufferSecurityCheck>false</BufferSecurityCheck>
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
       <FloatingPointModel>Fast</FloatingPointModel>
-      <FloatingPointExceptions>false</FloatingPointExceptions>
-      <CreateHotpatchableImage>false</CreateHotpatchableImage>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
-      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <Version>0.16</Version>
@@ -257,28 +250,21 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <Optimization>MaxSpeed</Optimization>
-      <FunctionLevelLinking>false</FunctionLevelLinking>
-      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
       </AdditionalIncludeDirectories>
-      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
-      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
-      <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
       <BufferSecurityCheck>false</BufferSecurityCheck>
       <FloatingPointModel>Fast</FloatingPointModel>
-      <CreateHotpatchableImage>false</CreateHotpatchableImage>
-      <OmitFramePointers>true</OmitFramePointers>
-      <FloatingPointExceptions>false</FloatingPointExceptions>
       <ExceptionHandling>Sync</ExceptionHandling>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
-      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <Version>0.16</Version>

--- a/src/Makefile
+++ b/src/Makefile
@@ -69,26 +69,23 @@ AMD_APP_LIB =
 endif
 
 # compiler settings for C and C++ files
-CC = gcc
-CPP = g++
-CFLAGS = $(ARCHFLAGS) $(BITS) -Wall $(OPTIMIZE_FLAG) $(AMD_APP_INCLUDE)
+CC ?= gcc
+CXX ?= g++
+CFLAGS = -std=gnu99 $(ARCHFLAGS) $(BITS) -Wall -Wextra $(OPTIMIZE_FLAG) $(AMD_APP_INCLUDE)
+CXXFLAGS = -std=gnu++11 $(ARCHFLAGS) $(BITS) -Wall -Wextra $(OPTIMIZE_FLAG) $(AMD_APP_INCLUDE)
 CFLAGS_EXTRA_SIEVE =
 CPPFLAGS =
 
 # linker settings
-LD = $(CPP)
+LD = $(CXX)
 LDFLAGS = $(ARCHFLAGS) $(BITS) $(STATIC) $(OPTIMIZE_FLAG) $(AMD_APP_LIB) $(OPENCL_LIB)
 
-CC_VERSION = $(shell $(CC) --version)
-
 # optimize or debug
-ifneq (, $(findstring gcc, $(CC_VERSION)))
-  OPTIMIZE_FLAG = -O3 -funroll-loops -ffast-math -finline-functions -frerun-loop-opt -fgcse-sm -fgcse-las -flto=auto -save-temps
-  CFLAGS_EXTRA_SIEVE = -funroll-all-loops -funsafe-loop-optimizations -fira-region=all -fsched-spec-load -fsched-stalled-insns=10 -fsched-stalled-insns-dep=10 -fno-align-labels
-else ifneq (, $(findstring clang, $(CC_VERSION)))
-  OPTIMIZE_FLAG = -O3 -funroll-loops -ffast-math -finline-functions -flto=auto -save-temps
+ifeq ($(DEBUG), 1)
+  OPTIMIZE_FLAG = -g -Og
 else
-  OPTIMIZE_FLAG = -O3
+  OPTIMIZE_FLAG = -O3 -funroll-loops -ffast-math -flto
+  CFLAGS_EXTRA_SIEVE = -funroll-all-loops
 endif
 
 ##############################################################################
@@ -121,7 +118,7 @@ sieve.o : sieve.c
 	$(CC) $(CFLAGS) -c $< -o $@
 
 %.o : %.cpp
-	$(CPP) $(CFLAGS) $(CPPFLAGS) -c $< -o $@
+	$(CXX) $(CXXFLAGS) $(CPPFLAGS) -c $< -o $@
 
 ../%.cl : %.cl
 	$(INSTALL) -m 444 $< ..

--- a/src/output.c
+++ b/src/output.c
@@ -67,6 +67,9 @@ void print_help(char *string)
 
 
 
+#ifdef __GNUC__
+__attribute__ ((format(printf, 2, 3)))
+#endif
 void logprintf(mystuff_t* mystuff, const char* fmt, ...)
 {
     va_list args;

--- a/src/output.h
+++ b/src/output.h
@@ -22,6 +22,9 @@ along with mfaktc.  If not, see <http://www.gnu.org/licenses/>.
 extern "C" {
 #endif
 void print_help(char *string);
+#ifdef __GNUC__
+__attribute__ ((format(printf, 2, 3)))
+#endif
 void logprintf(mystuff_t *mustuff, const char *fmt, ...);
 
 void print_dez72(int96 a, char *buf);


### PR DESCRIPTION
This backports many of the same improvements that I made to PRPLL-NTT in https://github.com/gwoltman/gpuowl/pull/7 and https://github.com/gwoltman/gpuowl/pull/8.

* Changed the existing CI workflow into a separate CD workflow
  * Changed to build the Linux executable on CentOS 7 instead of Ubuntu 24.04
    * This lowered the required glibc version from 2.39 to 2.17.
  * Changed to build the macOS executables on macOS 26 instead of 14/15 (still targeting macOS 11)
  * (This kept the separate MSVC and MSYS2 executables on Windows, but you should probably pick just one. The CI would still test both.)
* Added new CI workflow
  * Added tests with multiple Ubuntu and macOS versions
  * Added tests with Clang on Linux and Windows
  * Changed to build the debug executables, as the CD workflow now builds the release executables
* Updated Makefile
  * Added new `DEBUG` flag
  * Added separate C and C++ arguments
  * Removed separate optimization flags based on the compiler, including obsolete flags for GCC
* Updated MSVC project file
  * Enabled compiler warnings
  * Removed obsolete and redundant optimization flags
* Enabled GCC/Clang to check the printf style arguments to the `logprintf()` function calls

Also see: https://github.com/primesearch/mfaktc/pull/111